### PR TITLE
Deserializing to list of string fails

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -530,9 +530,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  type: string
-                type: array
+                type: string
           description: OK
       summary: List all pinned content
       tags:


### PR DESCRIPTION
In `/content/list` service, list of objects is returned. 

Java client is configured to desirealize to list of strings. This results in `Expected a string but was BEGIN_OBJECT at line 1` error. The error can be regenerated using `ContentApiTest.contentListGetTest` test case after uploading 1-2 files.
